### PR TITLE
change the mount name to mountDest in the rancher-nfs script

### DIFF
--- a/docker/volumeplugin/exec.go
+++ b/docker/volumeplugin/exec.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	statusSuccess      = "Success"
-	statusFailure      = "Failed"
+	statusFailure      = "Failure"
 	statusNotSupported = "Not supported"
 )
 

--- a/docker/volumeplugin/plugin.go
+++ b/docker/volumeplugin/plugin.go
@@ -124,6 +124,8 @@ func (d *RancherStorageDriver) Get(request volume.Request) volume.Response {
 }
 
 func (d *RancherStorageDriver) Remove(request volume.Request) volume.Response {
+	logrus.Infof("Docker Remove request: %v", request)
+
 	_, rVol, err := d.state.Get(request.Name)
 	if err == errNoSuchVolume {
 		return volume.Response{}
@@ -131,6 +133,7 @@ func (d *RancherStorageDriver) Remove(request volume.Request) volume.Response {
 		return volErr(err)
 	}
 
+	// Docker removal is fake, unless Rancher initiated removal of resource, then we do it.
 	if rVol.State == "removing" {
 		_, err := d.exec("delete", toArgs(request.Name, getOptions(rVol)))
 		if err != nil {

--- a/package/common/common.sh
+++ b/package/common/common.sh
@@ -96,3 +96,19 @@ ismounted() {
         echo "0"
     fi
 }
+
+init_nfs_client_service() {
+    # using host network context to start rpcbind and rpc.statd inside the container process.
+    # this requires mapping host pid namespace to this containers when container starts.
+    # here parent is the storage --driver rancher-nfs process, the script process is launched
+    # on demand of each create/delete etc calls, so host process pid is 2 hops away
+    PARENT_PID=$(ps --no-header --pid $$ -o ppid)
+    TARGET_PID=$(ps --no-header --pid ${PARENT_PID} -o ppid)
+    nsenter -t $TARGET_PID -n rpcbind >& /dev/null
+    nsenter -t $TARGET_PID -n rpc.statd >& /dev/null
+}
+
+get_host_process_pid() {
+    PARENT_PID=$(ps --no-header --pid $$ -o ppid)
+    TARGET_PID=$(ps --no-header --pid ${PARENT_PID} -o ppid)
+}

--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -257,7 +257,7 @@ detach() {
     print_success
 }
 
-mount() {
+mountdest() {
     print_not_supported
 }
 

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -70,6 +70,7 @@ wait_mount_target_deleting() {
 
 init()
 {
+    init_nfs_client_service
     print_success
 }
 
@@ -190,7 +191,7 @@ detach() {
     print_not_supported
 }
 
-mount() {
+mountdest() {
     if [ -z "${OPTS[fsid]}" ]; then
         print_error "fsid is required"
     fi
@@ -213,7 +214,8 @@ mount() {
 
     efsDNSName=${EC2_AVAIL_ZONE}.${OPTS[fsid]}.efs.${EC2_REGION}.amazonaws.com
     mkdir -p "${MNT_DEST}"
-    local error=`mount -t nfs4 ${mntOptions} ${efsDNSName}:${OPTS[export]} ${MNT_DEST} 2>&1`
+    get_host_process_pid
+    local error=`nsenter -t $TARGET_PID -n mount -t nfs4 ${mntOptions} ${efsDNSName}:${OPTS[export]} ${MNT_DEST} 2>&1`
     if [ $? -ne 0 ]; then
         print_error "Failed to mount ${efsDNSName}:${OPTS[export]} at ${MNT_DEST}. ${error}"
     fi

--- a/package/nfs/Dockerfile
+++ b/package/nfs/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 RUN apt-get update && \
-    apt-get install -y jq curl
+    apt-get install -y jq curl nfs-common
 COPY storage /usr/bin/
 COPY nfs/rancher-nfs common/* /usr/bin/
 CMD ["start.sh", "storage", "--driver-name", "rancher-nfs"]

--- a/package/nfs/rancher-nfs
+++ b/package/nfs/rancher-nfs
@@ -13,20 +13,26 @@ mount_default_share() {
     local mntDest=$1
 
     # get host:export from environment variables
-    if [ -z "${HOST}" ]; then
-        print_error "Failure: No environment variable HOST found\"}"
+    if [ -z "${NFS_SERVER}" ]; then
+        print_error "Failure: No environment variable NFS_SERVER found\"}"
     fi
 
-    if [ -z "${EXPORT}" ]; then
-        print_error "Failure: No environment variable EXPORT found\"}"
+    if [ -z "${MOUNT_DIR}" ]; then
+        print_error "Failure: No environment variable MOUNT_DIR found\"}"
+    fi
+
+    local mntOptions=""
+    if [ ! -z "${MOUNT_OPTS}" ]; then
+        mntOptions="-o ${MOUNT_OPTS}"
     fi
 
     # mount remote share if not mounted already
     if [ $(ismounted "${mntDest}") == 0 ] ; then
         mkdir -p "${mntDest}"
-        error=`mount "${HOST}":"${EXPORT}" "${mntDest}" 2>&1`
+        get_host_process_pid
+        error=`nsenter -t ${TARGET_PID} -n mount "${NFS_SERVER}":"${MOUNT_DIR}" "${mntDest}" 2>&1`
         if [ $? -ne 0 ]; then
-            print_error "Failed mount ${HOST}:${EXPORT} ${mntDest}: ${error}"
+            print_error "Failed mount ${mntOptions} ${NFS_SERVER}:${MOUNT_DIR} ${mntDest}: ${error}"
         fi
     fi
 }
@@ -48,6 +54,7 @@ unmount_default_share() {
 
 init()
 {
+    init_nfs_client_service
     print_success
 }
 
@@ -116,7 +123,7 @@ detach() {
     print_not_supported
 }
 
-mount() {
+mountdest() {
     local mntOptions=""
     if [ ! -z "${OPTS[mntOptions]}" ]; then
         mntOptions="-o ${OPTS[mntOptions]}"
@@ -127,25 +134,30 @@ mount() {
     # if user does not supply host:export, we will mount remote share host:export/name to mntDst
     if [ -z "${OPTS[host]}" ] || [ -z "${OPTS[export]}" ]; then
         # get host:export from environment variables
-        if [ -z "${HOST}" ]; then
-            print_error "Failed: No environment variable HOST found"
+        if [ -z "${NFS_SERVER}" ]; then
+            print_error "Failed: No environment variable NFS_SERVER found"
         fi
 
-        if [ -z "${EXPORT}" ]; then
-            print_error "Failed: No environment variable EXPORT found"
+        if [ -z "${MOUNT_DIR}" ]; then
+            print_error "Failed: No environment variable MOUNT_DIR found"
         fi
 
         if [ -z "${OPTS[name]}" ]; then
             print_error "Failed: name is required"
         fi
 
-        mntSrc="${HOST}":"${EXPORT}"/"${OPTS[name]}"
+        if [ ! -z "${MOUNT_OPTS}" ]; then
+            mntOptions="-o ${MOUNT_OPTS}"
+        fi
+
+        mntSrc="${NFS_SERVER}":"${MOUNT_DIR}"/"${OPTS[name]}"
     fi
 
     # mount remote share if not mounted already
     if [ $(ismounted "${MNT_DEST}") == 0 ] ; then
         mkdir -p "${MNT_DEST}"
-        error=`mount ${mntOptions} ${mntSrc} ${MNT_DEST} 2>&1`
+        get_host_process_pid
+        error=`nsenter -t ${TARGET_PID} -n mount ${mntOptions} ${mntSrc} ${MNT_DEST} 2>&1`
         if [ $? -ne 0 ]; then
             print_error "Failed mount ${mntOptions} ${mntSrc} ${MNT_DEST}: ${error}"
         fi


### PR DESCRIPTION
@ibuildthecloud 
- change the mount name to mountDest in the rancher-nfs script
- run NFS client service in host network context using nsenter, so we can mount with rpcbind and rpc.statd running
