### PR TITLE
add a GetAny method to RancherState in order to get any existing volu…

### DIFF
--- a/docker/volumeplugin/plugin.go
+++ b/docker/volumeplugin/plugin.go
@@ -97,6 +97,7 @@ func (d *RancherStorageDriver) Create(request volume.Request) volume.Response {
 	}
 
 	if err := d.state.Save(request.Name, result); err != nil {
+		logrus.Debugf("Save volume name=%s failed, err: %s", request.Name, err)
 		d.exec("delete", toArgs(request.Name, result))
 		return volErr(err)
 	}

--- a/package/efs/Dockerfile
+++ b/package/efs/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 RUN apt-get update && \
-    apt-get install -y jq python2.7 python-pip curl
+    apt-get install -y jq python2.7 python-pip curl nfs-common
 RUN pip install awscli
 COPY storage /usr/bin/
 COPY efs/rancher-efs common/* /usr/bin/


### PR DESCRIPTION
@ibuildthecloud 

add a GetAny method to RancherState in order to get any existing volume regardless of its state. This would allow Rancher creates a volume resource first at detached state. Then Docker volume create will do an update on the resource, instead of trying to ask Rancher to create a new resource, which will cause a Name Not Unique error.
