### PR TITLE
unset AWS credential environment variables inside storage plugin drivers

### DIFF
--- a/package/common/common.sh
+++ b/package/common/common.sh
@@ -112,3 +112,10 @@ get_host_process_pid() {
     PARENT_PID=$(ps --no-header --pid $$ -o ppid)
     TARGET_PID=$(ps --no-header --pid ${PARENT_PID} -o ppid)
 }
+
+unset_aws_credentials_env() {
+    if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ]; then
+        unset AWS_ACCESS_KEY_ID
+        unset AWS_SECRET_ACCESS_KEY
+    fi
+}

--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -11,7 +11,7 @@ elif [ -e "$(dirname $0)/../common/common.sh" ]; then
 fi
 
 get_meta_data() {
-    EC2_AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone`
+    EC2_AVAIL_ZONE=`curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone 2>/dev/null`
     EC2_REGION="`echo \"$EC2_AVAIL_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
     INSTANCE_ID=`curl http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null`
 }
@@ -150,6 +150,8 @@ create() {
         type_option="--volume-type ${type}"
     fi
 
+    unset_aws_credentials_env
+
     get_meta_data
 
     # create a EBS volume using aws-cli
@@ -183,6 +185,8 @@ delete() {
 
     VOLUME_ID=${OPTS[volumeID]}
 
+    unset_aws_credentials_env
+
     get_meta_data
 
     local volumes=`aws ec2 describe-volumes --region ${EC2_REGION} --volume-ids ${VOLUME_ID} 2>&1`
@@ -210,7 +214,10 @@ attach() {
 
     VOLUME_ID=${OPTS[volumeID]}
 
+    unset_aws_credentials_env
+
     get_meta_data
+
     detach_if_attached
 
     local device_path=$(find_available_device_path)
@@ -230,6 +237,8 @@ attach() {
 
 detach() {
     local aws_device_path="/dev/sd""${DEVICE: -1}"
+
+    unset_aws_credentials_env
 
     get_meta_data
 

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -95,6 +95,8 @@ create() {
         performanceMode="--performance-mode ${OPTS[performanceMode]}"
     fi
 
+    unset_aws_credentials_env
+
     get_meta_data
 
     # create a EFS FS using aws-cli
@@ -160,6 +162,8 @@ delete() {
     FSID=${OPTS[fsid]}
     MOUNT_TARGET_ID=${OPTS[mountTargetId]}
 
+    unset_aws_credentials_env
+
     get_meta_data
 
     local error=`aws efs delete-mount-target --region ${EC2_REGION} --mount-target-id ${MOUNT_TARGET_ID} 2>&1`
@@ -209,6 +213,8 @@ mountdest() {
         print_success
         exit 0
     fi
+
+    unset_aws_credentials_env
 
     get_meta_data
 


### PR DESCRIPTION
@ibuildthecloud 
As discussed, we need to unset AWS credential environment variables inside plugin containers in case user does not provide any optional credentials when start the Docker volume plugin rancher-xxx catalogs. So awscli inside containers will try to use IAM role permissions instead of empty credentials from env variables.
