### PR TITLE
Mount nfs dirs in host net namespace

### DIFF
--- a/package/common/common.sh
+++ b/package/common/common.sh
@@ -104,3 +104,8 @@ unset_aws_credentials_env() {
         unset AWS_SECRET_ACCESS_KEY
     fi
 }
+
+get_host_process_pid() {
+    PARENT_PID=$(ps --no-header --pid $$ -o ppid)
+    TARGET_PID=$(ps --no-header --pid ${PARENT_PID} -o ppid)
+}

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -216,8 +216,10 @@ mountdest() {
 
     efsDNSName=${EC2_AVAIL_ZONE}.${OPTS[fsid]}.efs.${EC2_REGION}.amazonaws.com
     mkdir -p "${MNT_DEST}"
+    get_host_process_pid
     local error
-    error=`mount -t nfs4 ${mntOptions} ${efsDNSName}:/ ${MNT_DEST} 2>&1`
+    error=`nsenter -t $TARGET_PID -n mount -t nfs4 ${mntOptions} ${efsDNSName}:${OPTS[export]} ${MNT_DEST} 2>&1`
+
     if [ $? -ne 0 ]; then
         print_error "Failed to mount ${efsDNSName}:/ at ${MNT_DEST}. ${error}"
     fi

--- a/package/nfs/rancher-nfs
+++ b/package/nfs/rancher-nfs
@@ -29,7 +29,8 @@ mount_default_share() {
     # mount remote share if not mounted already
     if [ $(ismounted "${mntDest}") == 0 ] ; then
         mkdir -p "${mntDest}"
-        error=`mount "${NFS_SERVER}":"${MOUNT_DIR}" "${mntDest}" 2>&1`
+        get_host_process_pid
+        error=`nsenter -t ${TARGET_PID} -n mount "${NFS_SERVER}":"${MOUNT_DIR}" "${mntDest}" 2>&1`
         if [ $? -ne 0 ]; then
             print_error "Failed mount ${mntOptions} ${NFS_SERVER}:${MOUNT_DIR} ${mntDest}: ${error}"
         fi
@@ -160,8 +161,9 @@ mountdest() {
     # mount remote share if not mounted already
     if [ $(ismounted "${MNT_DEST}") == 0 ] ; then
         mkdir -p "${MNT_DEST}"
+        get_host_process_pid
         local error
-        error=`mount ${mntOptions} ${mntSrc} ${MNT_DEST} 2>&1`
+        error=`nsenter -t ${TARGET_PID} -n mount ${mntOptions} ${mntSrc} ${MNT_DEST} 2>&1`
         if [ $? -ne 0 ]; then
             print_error "Failed mount ${mntOptions} ${mntSrc} ${MNT_DEST}: ${error}"
         fi


### PR DESCRIPTION
This is needed if you are connecting to a share that is in secure mode.
If you are not in the host net namespace, network address translation
causes the traffic to go over a port that the nfs server doesn't like.