### PR TITLE
add snapshot, encryption and tags options to EBS volume creation

### DIFF
--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -122,13 +122,29 @@ create() {
         type_option="--volume-type ${type}"
     fi
 
+    local snapshot=${OPTS[snapshotID]}
+    local snapshot_option=""
+    if [ ! -z "${snapshot}" ]; then
+        snapshot_option="--snapshot-id ${snapshot}"
+    fi
+
+    local encrypted=${OPTS[encrypted]}
+    local encrypted_option=""
+    if [ "${encrypted}" == "true" ]; then
+      if [ -z "${OPTS[kmsKeyId]}" ]; then
+          print_error "kmsKeyId is required for an encrypted volume"
+      else
+          encrypted_option="--encrypted --kms-key-id ${OPTS[kmsKeyId]}"
+      fi
+    fi
+
     unset_aws_credentials_env
 
     get_meta_data
 
     # create a EBS volume using aws-cli
     local volume
-    volume=`aws ec2 create-volume --region ${EC2_REGION} --size ${OPTS[size]} --availability-zone ${EC2_AVAIL_ZONE} ${type_option} ${iops_option} 2>&1`
+    volume=`aws ec2 create-volume --region ${EC2_REGION} --size ${OPTS[size]} --availability-zone ${EC2_AVAIL_ZONE} ${type_option} ${iops_option} ${snapshot_option} ${encrypted_option} 2>&1`
     if [ $? -ne 0 ]; then
         # now volume is the error message
         print_error "Failed in create: ${volume}"

--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -171,9 +171,12 @@ create() {
         print_error $device_path
     fi
 
-    error=`mkfs.ext4 -F $device_path 2>&1`
-    if [ $? -ne 0 ]; then
-        print_error $error
+    # don't format the volume if snapshot is set
+    if [ -z "${snapshot}" ]; then
+        error=`mkfs.ext4 -F $device_path 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error $error
+        fi
     fi
 
     do_detach $device_path

--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -138,6 +138,11 @@ create() {
       fi
     fi
 
+    local additional_tags=""
+    if [ ! -z "${OPTS[tags]}" ]; then
+        additional_tags="${OPTS[tags]}"
+    fi
+
     unset_aws_credentials_env
 
     get_meta_data
@@ -155,9 +160,9 @@ create() {
 
     # tag the newly created volume
     local error
-    error=`aws ec2 create-tags --region ${EC2_REGION} --resources ${VOLUME_ID} --tags Key=Name,Value=${OPTS[name]} 2>&1`
+    error=`aws ec2 create-tags --region ${EC2_REGION} --resources ${VOLUME_ID} --tags Key=Name,Value=${OPTS[name]} ${additional_tags} 2>&1`
     if [ $? -ne 0 ]; then
-        print_error "Failed in create: create-tags for volume ${VOLUME_ID} Key=Name,Value=${OPTS[name]} failed. ${error}"
+        print_error "Failed in create: create-tags for volume ${VOLUME_ID} Key=Name,Value=${OPTS[name]} ${additional_tags} failed. ${error}"
     fi
 
     local device_path


### PR DESCRIPTION
The EBS volume creation did not have the snapshot-id and encryption options available to it.  I know we would like to use those options for our environment and i belive others will as well.

It adds the following options to the driver_options sections:

snapshotID
encryption ("true" enables it)
kmsKeyID (only looked for if encryption enabled)
tags

example usage: 
```
volumes:
  data:
    driver: rancher-ebs
    per_container: true
    driver_opts:
      name: test_data
      size: 10
      volumeType: gp2
      snapshotID: <some snapshot id>
      encryption: true
      kmsKeyID: <some keyid> 
      tags: "Key=Stack,Value=production Key=webserver,Value= "
```