### PR TITLE
Add azurefile drver

### DIFF
--- a/package/azurefile/Dockerfile
+++ b/package/azurefile/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y jq curl cifs-utils python-pip libssl-dev libffi-dev && \
+    pip install azure-storage && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+COPY storage /usr/bin/
+COPY azurefile/rancher-azurefile azurefile/azurefile-share.py common/* /usr/bin/
+CMD ["start.sh", "storage", "--driver-name", "rancher-azurefile"]

--- a/package/azurefile/Readme.md
+++ b/package/azurefile/Readme.md
@@ -13,6 +13,17 @@ If the file share doesn't already exist it will be created by the mount process.
 This is a SMB v3 file share using the mount.cifs binary. As such it may not be appropriate for all workloads. See here for a list of things that the Azure File service doesn't support: [Features Not Supported By the Azure File Service](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/features-not-supported-by-the-azure-file-service)
 
 ### Azure Files plugin driver is a bash script and invocation commands are:
+**Create:**  
+Create Azure File Share under specified storage account.
+```
+driver  create json_options
+```
+
+**Delete:**  
+Delete Azure File Share if driver option on volume `delete_on_terminate` is set to `true`
+```
+driver  delete json_options
+```
 
 **Mount:**
 ```
@@ -25,7 +36,7 @@ driver  unmount  mountpoint
 ```
 
 **Other Functions:**  
-create, delete, attach, detach functions don't do anything.  
+attach, detach functions don't do anything.  
 
 ### Usage
 Launch this stack with the Azure Storage Account Name and Key, then define a `version: "2"` style volume entry in your user stack `docker-compose.yml`.
@@ -40,11 +51,11 @@ Launch this stack with the Azure Storage Account Name and Key, then define a `ve
 
 #### Named `share` Option or Rancher Generated Name
 
-You can specify a `share` name or let Rancher generate one base on volume scope.
+You can specify a `share` name or let Rancher generate one based on volume scope.
 See [Rancher Persistent Storage](http://docs.rancher.com/rancher/v1.2/en/rancher-services/storage-service/#storage-service) documentation for more details on scope names.
 
 If you use `share`:
-* `share` supports %{environment_name} template substitution.
+* `share` supports `%{environment_name}` template substitution to include the environment name.
 * `share` must match [a-z0-9\\-] - This is an Azure limitation.
 
 #### Example
@@ -61,10 +72,10 @@ volumes:
   test_volume:
     driver: rancher-azurefile
     driver_opts:
-      share: test-share
+      share: "%{environment-name}-test-share"
       file_mode: "0644"
       dir_mode: "0755"
       uid: "100"
       gid: "101"
-      mount_opts: nolock,rw
+      mount_opts: "nolock,rw"
 ```

--- a/package/azurefile/Readme.md
+++ b/package/azurefile/Readme.md
@@ -1,0 +1,70 @@
+## Rancher AzureFile Volume Plugin Driver
+
+Mount a File Share on an Azure Storage Account.
+
+### Requirements
+
+* Azure Storage Account
+* The Storage Account Key
+
+If the file share doesn't already exist it will be created by the mount process.
+
+### Limitations
+This is a SMB v3 file share using the mount.cifs binary. As such it may not be appropriate for all workloads. See here for a list of things that the Azure File service doesn't support: [Features Not Supported By the Azure File Service](https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/features-not-supported-by-the-azure-file-service)
+
+### Azure Files plugin driver is a bash script and invocation commands are:
+
+**Mount:**
+```
+driver  mount  mountpoint  json_options
+```
+
+**Unmount:**
+```
+driver  unmount  mountpoint
+```
+
+**Other Functions:**  
+create, delete, attach, detach functions don't do anything.  
+
+### Usage
+Launch this stack with the Azure Storage Account Name and Key, then define a `version: "2"` style volume entry in your user stack `docker-compose.yml`.
+
+#### Available Driver Options:
+
+* `file_mode` (Default: 0644)
+* `dir_mode`  (Default: 0755)
+* `uid`       (Default: 0)
+* `gid`       (Default: 0)
+* `mount_opts` - Comma separated list of additional [`mount.cifs(8)`](https://linux.die.net/man/8/mount.cifs) options.
+
+#### Named `share` Option or Rancher Generated Name
+
+You can specify a `share` name or let Rancher generate one base on volume scope.
+See [Rancher Persistent Storage](http://docs.rancher.com/rancher/v1.2/en/rancher-services/storage-service/#storage-service) documentation for more details on scope names.
+
+If you use `share`:
+* `share` supports %{environment_name} template substitution.
+* `share` must match [a-z0-9\\-] - This is an Azure limitation.
+
+#### Example
+```
+version: "2"
+
+services:
+  test:
+    image: busybox
+    volumes:
+      - test_volume:/data
+
+volumes:
+  test_volume:
+    driver: rancher-azurefile
+    driver_opts:
+      share: test-share
+      file_mode: "0644"
+      dir_mode: "0755"
+      uid: "100"
+      gid: "101"
+      mount_opts: nolock,rw
+```

--- a/package/azurefile/azurefile-share.py
+++ b/package/azurefile/azurefile-share.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# Simple script to create and delete shares
+# Trying to do this with curl == (╯°□°）╯︵ ┻━┻ - Jason Greathouse (jgreat)
+
+import os
+import argparse
+import re
+import sys
+from azure.storage.file import FileService
+
+parser = argparse.ArgumentParser(description='Create or Delete a File Share')
+parser.add_argument('command', nargs=1, help='<create|delete>')
+parser.add_argument('share', nargs=1, help='<share>')
+
+opts = parser.parse_args()
+command = opts.command[0]
+share = opts.share[0]
+
+if re.match(command, '(create|delete)'):
+    print('invaid command argument')
+    sys.exit(1)
+
+if not share:
+    print('no share argument')
+    sys.exit(1)
+
+account_name = os.getenv('AZURE_STORAGE_ACCOUNT')
+account_key = os.getenv('AZURE_STORAGE_ACCOUNT_KEY')
+
+file_service = FileService(account_name=account_name, account_key=account_key)
+
+if command == 'create':
+    if file_service.create_share(share):
+        print('Share created')
+    else:
+        print('Share alreaded exists')
+
+if command == 'delete':
+    if file_service.delete_share(share):
+        print('Share Deleted')
+    else:
+        print('Share not found')

--- a/package/azurefile/rancher-azurefile
+++ b/package/azurefile/rancher-azurefile
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# Notes:
+#  - Please install "jq" package before using this driver.
+
+if [ -e "$(dirname $0)/common.sh" ]; then
+    source $(dirname $0)/common.sh
+elif [ -e "$(dirname $0)/../common/common.sh" ]; then
+    source $(dirname $0)/../common/common.sh
+fi
+
+get_env() {
+    curl -sS http://rancher-metadata/latest/self/stack/environment_name
+}
+
+get_share_name() {
+    local share="${OPTS[name]//_/-}"
+
+    if [ "${OPTS[share]}" ]; then
+        share="${OPTS[share]}"
+    fi
+    # template substiution for environment name
+    local env=$(get_env)
+    echo -n "${share}" | sed -e "s/%{environment_name}/${env}/"
+}
+
+init()
+{
+    print_success "init"
+}
+
+create() {
+    local share=$(get_share_name)
+    local msg=$(azurefile-share.py create ${share} 2>&1)
+    print_success $msg
+}
+
+delete() {
+    local msg="delete_on_terminate not set. Not deleted"
+    local share=$(get_share_name)
+    if [ "${OPTS[delete_on_terminate]}" ]; then
+        msg=$(azurefile-share.py delete ${share} 2>&1)
+    fi
+    print_success $msg
+}
+
+attach() {
+    print_not_supported "attach"
+}
+
+detach() {
+    print_not_supported "detach"
+}
+
+mountdest() {
+    local mntOptions=()
+    mntOptions+=("vers=3.0")
+    if [ -z "${AZURE_STORAGE_ACCOUNT}" ]; then
+        print_error "Failed: No environment variable AZURE_STORAGE_ACCOUNT found"
+    else
+        mntOptions+=("username=${AZURE_STORAGE_ACCOUNT}")
+    fi
+    if [ -z "${AZURE_STORAGE_ACCOUNT_KEY}" ]; then
+        print_error "Failed: No environment variable AZURE_STORAGE_ACCOUNT_KEY found"
+    else
+        mntOptions+=("password=${AZURE_STORAGE_ACCOUNT_KEY}")
+    fi
+
+    if [ "${OPTS[file_mode]}" ]; then
+        mntOptions+=("file_mode=${OPTS[file_mode]}")
+    else
+        mntOptions+=("file_mode=0644")
+    fi
+
+    if [ "${OPTS[dir_mode]}" ]; then
+        mntOptions+=("dir_mode=${OPTS[dir_mode]}")
+    else
+        mntOptions+=("dir_mode=0755")
+    fi
+
+    if [ "${OPTS[uid]}" ]; then
+        mntOptions+=("uid=${OPTS[uid]}")
+    else
+        mntOptions+=("uid=0")
+    fi
+
+    if [ "${OPTS[gid]}" ]; then
+        mntOptions+=("gid=${OPTS[gid]}")
+    else
+        mntOptions+=("gid=0")
+    fi
+
+    if [ "${OPTS[mount_opts]}" ]; then
+        mntOptions+=("${OPTS[mount_options]}")
+    fi
+
+    local share=$(get_share_name)
+    local srcURI="//${AZURE_STORAGE_ACCOUNT}.file.core.windows.net"
+    local mntSrc="${srcURI}/${share}"
+
+    # mount remote share if not mounted already
+    if [ $(ismounted "${MNT_DEST}") == 0 ] ; then
+        mkdir -p "${MNT_DEST}"
+        get_host_process_pid
+        local error
+        local opts=$(join_by , "${mntOptions[@]}")
+        error=`nsenter -t ${TARGET_PID} -n mount -t cifs -o ${opts} ${mntSrc} ${MNT_DEST} 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error "Failed mount -t cifs -o ${opts} ${mntSrc} ${MNT_DEST}: ${error}"
+        fi
+    fi
+
+    print_success "mount Successful"
+}
+
+unmount() {
+    if [ $(ismounted "${MNT_DEST}") == 1 ] ; then
+        error=`umount "${MNT_DEST}" 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error "Failed umount ${MNT_DEST}: ${error}"
+        fi
+    fi
+
+    print_success "umount Successful"
+}
+
+join_by() {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+# Every script must call main as such
+main "$@"


### PR DESCRIPTION
We use Azure as our main provider and user Azure File Service for persistent storage. This PR adds a driver for Azure File Service cifs/smb mounts. 

See the package/azurefile/Readme.md for usage and more details.

I tried to follow the patterns in nfs and example folders. Let me know if you guys want any changes.

I also have a catalog entry for it. If you like the driver please let me know if you would like a PR to rancher/rancher-catalog or rancher/community-catalog.

