### PR TITLE
EFS volume driver - Option to add existing security group and mount on different availability zones

### DIFF
--- a/package/efs/Readme.md
+++ b/package/efs/Readme.md
@@ -73,7 +73,7 @@ stdout output: {"status":"Success","message":""}
 User needs to supplies volume name, and an optional security group Id/name which we can use to setup the mount. If the 
 security group name/id is not provided, then we create a new security group with port 2049 open to everyone.
 
-Note: We use the security group name _tag_ and *NOT* the group name.
+Note: We use the security group name _tag_ and **NOT** the group name.
 
 The driver creates a new file system at AWS EFS site and mounts it in the subnet of the EC2 instance where it is running
 and tags it using name.
@@ -82,26 +82,29 @@ The output is the status and newly created fsid etc
 
 ```
 ./efs create '{"creationToken":"anystring","name":"vol1","performanceMode":"maxIO",mountTargetSGName": "target.efs.mount.security.group"}'
+```
 
 name and creationToken key-value pairs must be provided in json_options and performanceMode & mountTargetSGName are optional parameters.
 
 If existing security group Id/Name is passed then we set the _useExistingSecGrp_ to _true_, so that we don't delete the security group
 while deleting the volume.
+
 ```
 {"status":"Success","options":{created": "true", "fsid": "fs-xxxxxxxx”, "mountTargetSGID": "sg-xxxxxxxx”, ”mountTargetSGName":"target.efs.mount.security.group", "name": "efsPubPrivTest03_EFS", "useExistingSecGrp": "true"}}
 ```
 
 the options map from the output will be passed in as part of json_input for delete command
-```
 
 ##### Delete command
 driver deletes created EFS file system along with the security group if existing security group was not provided to the create command.
 
 ```
 ./efs delete '{created": "true", "fsid": "fs-xxxxxxxx”, "mountTargetSGID": "sg-xxxxxxxx”, ”mountTargetSGName":"target.efs.mount.security.group", "name": "efsPubPrivTest03_EFS", "useExistingSecGrp": "true"}'
+```
 
 the options map from create command output is passed in to delete command as part of json_input
 
+```
 stdout output: {"status":"Success","message":""}
 ```
 
@@ -112,9 +115,11 @@ We check if mount point exists for this EFS volume in the EC2 instance subnet, i
 
 ```
 ./efs mount /home/ubuntu/efsMnt '{"fsid":"fs-b59c621c","export":"/","mntOptions":"ro,vers=4.1"}'
+```
 
 mntOptions key-value pair is optional for mount, but fsid and export are the must
 
+```
 stdout output: {"status":"Success","message":""}
 ```
 

--- a/package/efs/Readme.md
+++ b/package/efs/Readme.md
@@ -36,7 +36,7 @@ stdout output: {"status":"Success","message":""}
 ```
 
 ##### Delete command
-driver does nothing
+driver deletes the file system
 
 ```
 ./efs delete '{"fsid":"fs-90d12d39"}
@@ -70,24 +70,35 @@ stdout output: {"status":"Success","message":""}
 ### 2. User does not provide fsid
 
 ##### Create command
-user needs to supplies volume name, driver creates a new file system at AWS EFS site and tags it using name.
+User needs to supplies volume name, and an optional security group Id/name which we can use to setup the mount. If the 
+security group name/id is not provided, then we create a new security group with port 2049 open to everyone.
+
+Note: We use the security group name _tag_ and *NOT* the group name.
+
+The driver creates a new file system at AWS EFS site and mounts it in the subnet of the EC2 instance where it is running
+and tags it using name.
+
 The output is the status and newly created fsid etc
 
 ```
-./efs create '{"creationToken":"anystring","name":"vol1","performanceMode":"maxIO"}'
+./efs create '{"creationToken":"anystring","name":"vol1","performanceMode":"maxIO",mountTargetSGName": "target.efs.mount.security.group"}'
 
-name and creationToken key-value pairs must be provided in json_options and performanceMode is optional parameter
+name and creationToken key-value pairs must be provided in json_options and performanceMode & mountTargetSGName are optional parameters.
 
-stdout output: {"status":"Success","options":{"created":true,"fsid":"fs-b59c621c","mountTargetId":"fsmt-b20df41b"}}
+If existing security group Id/Name is passed then we set the _useExistingSecGrp_ to _true_, so that we don't delete the security group
+while deleting the volume.
+```
+{"status":"Success","options":{created": "true", "fsid": "fs-xxxxxxxx”, "mountTargetSGID": "sg-xxxxxxxx”, ”mountTargetSGName":"target.efs.mount.security.group", "name": "efsPubPrivTest03_EFS", "useExistingSecGrp": "true"}}
+```
 
 the options map from the output will be passed in as part of json_input for delete command
 ```
 
 ##### Delete command
-driver deletes created EFS file system
+driver deletes created EFS file system along with the security group if existing security group was not provided to the create command.
 
 ```
-./efs delete '{"created":true,"fsid":"fs-b59c621c","mountTargetId":"fsmt-b20df41b"}'
+./efs delete '{created": "true", "fsid": "fs-xxxxxxxx”, "mountTargetSGID": "sg-xxxxxxxx”, ”mountTargetSGName":"target.efs.mount.security.group", "name": "efsPubPrivTest03_EFS", "useExistingSecGrp": "true"}'
 
 the options map from create command output is passed in to delete command as part of json_input
 
@@ -95,7 +106,9 @@ stdout output: {"status":"Success","message":""}
 ```
 
 #### Mount command
-driver mounts EFS using fsid created at create command phase
+driver mounts EFS using fsid created at create command phase in the availability zone of the EC2 instance where the driver is running.
+
+We check if mount point exists for this EFS volume in the EC2 instance subnet, if not we create a new mount point in the EC2 instance's subnet.
 
 ```
 ./efs mount /home/ubuntu/efsMnt '{"fsid":"fs-b59c621c","export":"/","mntOptions":"ro,vers=4.1"}'
@@ -105,7 +118,7 @@ mntOptions key-value pair is optional for mount, but fsid and export are the mus
 stdout output: {"status":"Success","message":""}
 ```
 
-The result is that us-west-2b.fs-b59c621c.efs.us-west-2.amazonaws.com:/ is mounted to /home/ubuntu/efsMnt
+The result is that <availability zone>.fs-b59c621c.efs.us-west-2.amazonaws.com:/ is mounted to /home/ubuntu/efsMnt
 
 #### Unmount command
 driver unmount EFS file system

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -247,7 +247,7 @@ mountdest() {
         efsExport="/"
     fi
 
-    if [ $(ismounted "${MNT_DEST}") == 1 ] ; then
+    if [ $(ismounted "${MNT_DEST}") == 1 ]; then
         print_success
         exit 0
     fi
@@ -256,6 +256,32 @@ mountdest() {
 
     get_meta_data
 
+    local isMountPointAlreadyCreated=false
+    
+    # get the list of available subnets and store it into array named 'subnetMounts'
+    mapfile -n 0 -t subnetMounts < <(aws efs describe-mount-targets --region ${EC2_REGION}  --file-system-id ${OPTS[fsid]} | jq -c -r '.MountTargets[].SubnetId')
+
+    # Check if the EFS is already mounted in the current subnet
+    for ((i=0;i < ${#subnetMounts[@]} ; i+=1)) do
+        if [ "${SUBNET_ID}" == "${subnetMounts[i]}" ]; then
+            isMountPointAlreadyCreated=true
+        fi
+    done
+    
+    # Create a new mount-target in current region and subnet if one doesn't already exist
+    if [ "$isMountPointAlreadyCreated" == "false" ]; then
+        # create a mount target for the EFS
+        local fsMountTarget
+        fsMountTarget=`aws efs create-mount-target --region ${EC2_REGION} --file-system-id ${OPTS[fsid]} --subnet-id ${SUBNET_ID} --security-group ${OPTS[mountTargetSGID]} 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error "Failed in create: ${fsMountTarget}"
+        fi
+        
+        MOUNT_TARGET_ID=$(echo ${fsMountTarget} | jq -r '.MountTargetId')
+        
+        wait_mount_target_transition "creating" "available"
+    fi
+    
     local efsMountDNS="${EC2_AVAIL_ZONE}.${OPTS[fsid]}.efs.${EC2_REGION}.amazonaws.com"
     # Amazon takes a while to make the mount target resolvable via DNS, so wait up to 60 seconds
     for (( i=0; i<60; i=i+1 )); do

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -201,7 +201,7 @@ delete() {
 
     get_meta_data
 
-    # get the list of available subnets and store it into array named 'mountTargetsArray'
+    # get the list of available mount targets and store it into array named 'mountTargetsArray'
     mapfile -n 0 -t mountTargetsArray < <(aws efs describe-mount-targets --region ${EC2_REGION}  --file-system-id ${FSID} | jq -c -r '.MountTargets[].MountTargetId')
 
     local error

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -133,7 +133,7 @@ create() {
         # If security group name is provided then get the group id
         if [ ! -z "${OPTS[mountTargetSGName]}" ]; then
             local mountTargetSGIDResponse
-            mountTargetSGIDResponse=`aws ec2 describe-security-groups --region ${EC2_REGION} --filters Name=vpc-id,Values=${VPC_ID} --filters Name=group-name,Values=${OPTS[mountTargetSGName]} --query SecurityGroups[*].{GroupId:GroupId}`
+            mountTargetSGIDResponse=`aws ec2 describe-security-groups --region ${EC2_REGION} --filters Name=vpc-id,Values=${VPC_ID} --filters Name=tag-key,Values=Name Name=tag-value,Values=${OPTS[mountTargetSGName]} --query SecurityGroups[*].{GroupId:GroupId}`
             mountTargetSGID=$(echo ${mountTargetSGIDResponse} | jq -r '.[].GroupId')
         else
             mountTargetSGID=${OPTS[mountTargetSGID]}

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -92,7 +92,7 @@ create() {
         print_success
         exit 0
     fi
-
+    
     if [ -z "${OPTS[name]}" ]; then
         print_error "name is required"
     fi
@@ -106,6 +106,15 @@ create() {
 
     get_meta_data
 
+    # Check if an EFS volume with the same creation token exists
+    local existing_fs
+    existing_fs=`aws efs describe-file-systems --region ${EC2_REGION} --creation-token ${OPTS[name]} | grep -c ${OPTS[name]}`
+    
+    if [ $existing_fs -gt 0 ]; then
+        print_success
+        exit 0
+    fi
+    
     # create a EFS FS using aws-cli
     local fs
     fs=`aws efs create-file-system --region ${EC2_REGION} --creation-token ${OPTS[name]} ${performanceMode} 2>&1`
@@ -116,23 +125,34 @@ create() {
 
     wait_fs_transition "creating" "available"
 
-    # create a security group for mount target
-    local description="From cattle EFS driver, SG for mount target of EFS: ${FSID}"
-    local groupName="SG-Mount-Target-EFS-${FSID}"
-    local mtSG
-    mtSG=`aws ec2 create-security-group --region ${EC2_REGION} --vpc-id ${VPC_ID} --group-name ${groupName} --description "${description}" 2>&1`
-    if [ $? -ne 0 ]; then
-        print_error "Failed in create: create-security-group. ${mtSG}"
-    fi
-    local mountTargetSGID=$(echo ${mtSG} | jq -r '.GroupId')
+    # Use an existing security group if that is passed; else create a new security group
+    local mountTargetSGID
+    local useExistingSecGrp=true
+    
+    if [ ! -z "${OPTS[mountTargetSGID]}" ]; then
+        mountTargetSGID=${OPTS[mountTargetSGID]}
+    else
+         # create a security group for mount target
+        local description="From cattle EFS driver, SG for mount target of EFS: ${FSID}"
+        local groupName="SG-Mount-Target-EFS-${FSID}"
+        local mtSG
+        mtSG=`aws ec2 create-security-group --region ${EC2_REGION} --vpc-id ${VPC_ID} --group-name ${groupName} --description "${description}" 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error "Failed in create: create-security-group. ${mtSG}"
+        fi
+        
+        mountTargetSGID=$(echo ${mtSG} | jq -r '.GroupId')
 
-    # open NFS4.1 port 2049 on the security group just created
-    local error
-    error=`aws ec2 authorize-security-group-ingress --region ${EC2_REGION} --group-id ${mountTargetSGID} --protocol tcp --port 2049 --cidr 0.0.0.0/0 2>&1`
-    if [ $? -ne 0 ]; then
-        print_error "Failed in create: authorize-security-group-ingress for SG ${mountTargetSGID}. ${error}"
+        # open NFS4.1 port 2049 on the security group just created
+        local error
+        error=`aws ec2 authorize-security-group-ingress --region ${EC2_REGION} --group-id ${mountTargetSGID} --protocol tcp --port 2049 --cidr 0.0.0.0/0 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error "Failed in create: authorize-security-group-ingress for SG ${mountTargetSGID}. ${error}"
+        fi
+        
+        useExistingSecGrp=false
     fi
-
+    
     # create a mount target for the EFS
     local fsMountTarget
     fsMountTarget=`aws efs create-mount-target --region ${EC2_REGION} --file-system-id ${FSID} --subnet-id ${SUBNET_ID} --security-group ${mountTargetSGID} 2>&1`
@@ -149,7 +169,7 @@ create() {
         print_error "Failed in create: create-tags for EFS ${FSID} Key=Name,Value=${OPTS[name]} failed. ${error}}"
     fi
 
-    print_options created true fsid ${FSID} mountTargetId ${MOUNT_TARGET_ID} mountTargetSGID ${mountTargetSGID}
+    print_options created true fsid ${FSID} mountTargetId ${MOUNT_TARGET_ID} mountTargetSGID ${mountTargetSGID} useExistingSecGrp ${useExistingSecGrp}
 }
 
 delete() {

--- a/package/efs/rancher-efs
+++ b/package/efs/rancher-efs
@@ -62,7 +62,7 @@ wait_mount_target_deleting() {
     while [ "${num}" == 1 ]; do
         sleep ${WAIT_SLEEP_TIME_IN_SECONDS}
         local fileSystems
-        fileSystems=`aws efs describe-file-systems --region ${EC2_REGION} --file-system-id ${FSID} 2>&1`
+        fileSystems=`aws efs describe-file-systems --region ${EC2_REGION} --file-system-id ${FSID} --mount-target-id ${MOUNT_TARGET_ID} 2>&1`
         if [ $? -ne 0 ]; then
             err "{ \"status\": \"Failure\", \"message\": \"Failed to describe fs ${FSID}: ${fileSystems}\"}"
             exit 1
@@ -127,10 +127,19 @@ create() {
 
     # Use an existing security group if that is passed; else create a new security group
     local mountTargetSGID
-    local useExistingSecGrp=true
+    local useExistingSecGrp
     
-    if [ ! -z "${OPTS[mountTargetSGID]}" ]; then
-        mountTargetSGID=${OPTS[mountTargetSGID]}
+    if [ ! -z "${OPTS[mountTargetSGID]}" ] || [ ! -z "${OPTS[mountTargetSGName]}" ]; then
+        # If security group name is provided then get the group id
+        if [ ! -z "${OPTS[mountTargetSGName]}" ]; then
+            local mountTargetSGIDResponse
+            mountTargetSGIDResponse=`aws ec2 describe-security-groups --region ${EC2_REGION} --filters Name=vpc-id,Values=${VPC_ID} --filters Name=group-name,Values=${OPTS[mountTargetSGName]} --query SecurityGroups[*].{GroupId:GroupId}`
+            mountTargetSGID=$(echo ${mountTargetSGIDResponse} | jq -r '.[].GroupId')
+        else
+            mountTargetSGID=${OPTS[mountTargetSGID]}
+        fi
+        
+        useExistingSecGrp=true
     else
          # create a security group for mount target
         local description="From cattle EFS driver, SG for mount target of EFS: ${FSID}"
@@ -169,7 +178,7 @@ create() {
         print_error "Failed in create: create-tags for EFS ${FSID} Key=Name,Value=${OPTS[name]} failed. ${error}}"
     fi
 
-    print_options created true fsid ${FSID} mountTargetId ${MOUNT_TARGET_ID} mountTargetSGID ${mountTargetSGID} useExistingSecGrp ${useExistingSecGrp}
+    print_options created true fsid ${FSID} mountTargetSGID ${mountTargetSGID} useExistingSecGrp ${useExistingSecGrp}
 }
 
 delete() {
@@ -182,40 +191,48 @@ delete() {
         print_error "fsid is required"
     fi
 
-    if [ -z "${OPTS[mountTargetId]}" ]; then
-        print_error "mountTargetId is required"
-    fi
-
     if [ -z "${OPTS[mountTargetSGID]}" ]; then
         print_error "mountTargetSGID is required"
     fi
 
     FSID=${OPTS[fsid]}
-    MOUNT_TARGET_ID=${OPTS[mountTargetId]}
-
+    
     unset_aws_credentials_env
 
     get_meta_data
 
+    # get the list of available subnets and store it into array named 'mountTargetsArray'
+    mapfile -n 0 -t mountTargetsArray < <(aws efs describe-mount-targets --region ${EC2_REGION}  --file-system-id ${FSID} | jq -c -r '.MountTargets[].MountTargetId')
+
     local error
-    error=`aws efs delete-mount-target --region ${EC2_REGION} --mount-target-id ${MOUNT_TARGET_ID} 2>&1`
-    if [ $? -ne 0 ]; then
-        if [ "$(echo $error | grep 'MountTargetNotFound')" ]; then
-            print_success Mount target does not exist
-            exit 0
-        else
-            print_error "${MOUNT_TARGET_ID}: ${error}"
+    
+    # delete all the mount points associated with efs file system
+    for ((i=0;i < ${#mountTargetsArray[@]} ; i+=1)) do
+        
+        MOUNT_TARGET_ID=${mountTargetsArray[i]}
+        
+        error=`aws efs delete-mount-target --region ${EC2_REGION} --mount-target-id ${MOUNT_TARGET_ID} 2>&1`
+        if [ $? -ne 0 ]; then
+            if [ "$(echo $error | grep 'MountTargetNotFound')" ]; then
+                print_success Mount target does not exist
+                exit 0
+            else
+                print_error "${MOUNT_TARGET_ID}: ${error}"
+            fi
+        fi
+
+        wait_mount_target_deleting
+    done
+    
+    # Delete the security group if it was created as part of EFS instance creation
+    if [ "${OPTS[useExistingSecGrp]}" == "false" ]; then
+        local mountTargetSGID=${OPTS[mountTargetSGID]}
+        error=`aws ec2 delete-security-group --region ${EC2_REGION} --group-id ${mountTargetSGID} 2>&1`
+        if [ $? -ne 0 ]; then
+            print_error "Failed to delete mount target security group ${mountTargetSGID}. ${error}"
         fi
     fi
-
-    wait_mount_target_deleting
-
-    local mountTargetSGID=${OPTS[mountTargetSGID]}
-    error=`aws ec2 delete-security-group --region ${EC2_REGION} --group-id ${mountTargetSGID} 2>&1`
-    if [ $? -ne 0 ]; then
-        print_error "Failed to delete mount target security group ${mountTargetSGID}. ${error}"
-    fi
-
+    
     error=`aws efs delete-file-system --region ${EC2_REGION} --file-system-id ${FSID} 2>&1`
     if [ $? -ne 0 ]; then
         print_error "Failed to delete volume ${FSID}. ${error}"


### PR DESCRIPTION
Our use case is to create a new EFS volume as part of deployment and then mount that across a cluster of application servers spread across multiple availability zones.

Following functionality is added

- Create

1.  Added check to return if EFS volume with the same name already exists in the region. This is not a substitute for ordering your container dependencies but more as a fallback if someone doesn't do that.
2. Use existing security group if the security group id or "name" tag is passed in options

- Mount

1. Check if mount point already created in current subnet; if not create a new mount point

- Delete

1. First delete all mount points related to this EFS volume.
2. Delete the security group if it was created specifically for this EFS entry.