### PR TITLE
tweak build scripts to be able to build just one driver image

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,9 +1,8 @@
 #!/bin/bash
-set -e
-
-source $(dirname $0)/version
+set -e -x
 
 cd $(dirname $0)/..
+VERSION=${VERSION:-$(./scripts/version)}
 
 mkdir -p bin
 [ "$(uname)" != "Darwin" ] && LINKFLAGS="-linkmode external -extldflags -static -s"

--- a/scripts/package
+++ b/scripts/package
@@ -1,21 +1,28 @@
 #!/bin/bash
 set -e
 
-source $(dirname $0)/version
+cd $(dirname $0)/..
 
-ARCH=${ARCH:?"ARCH not set"}
+ARCH=${ARCH:-amd64}
 SUFFIX=""
 [ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
 
-cd $(dirname $0)/../package
+export VERSION=${VERSION:-$(./scripts/version)}
+cd ./package
 
-TAG=${TAG:-${IMAGE_VERSION}${SUFFIX}}
+TAG=${TAG:-${VERSION}${SUFFIX}}
 REPO=${REPO:-rancher}
+
+if [[ "$1" != "" && ! -e "$1/Dockerfile" ]]; then
+    echo no such file "./package/$1/Dockerfile"
+    exit 1
+fi
 
 if [ ! -e ../bin/storage ]; then
     ../scripts/build
 fi
 
+mkdir -p ../dist
 > ../dist/images
 
 cp ../bin/storage .
@@ -24,12 +31,20 @@ SSL_SCRIPT_COMMIT=98660ada3d800f653fc1f105771b5173f9d1a019
 curl -sLf https://raw.githubusercontent.com/rancher/rancher/${SSL_SCRIPT_COMMIT}/server/bin/update-rancher-ssl > ../package/common/update-rancher-ssl
 chmod +x ../package/common/update-rancher-ssl
 
-for i in */Dockerfile; do
-    BASE=$(dirname $i)
+build_image() {
+    BASE=$(dirname $1)
     IMAGE=${REPO}/storage-${BASE}:${TAG}
-    docker build -f $i -t ${IMAGE} .
+    docker build -f $1 -t ${IMAGE} .
     if [ "$BASE" != "example" ]; then
         echo ${IMAGE} >> ../dist/images
     fi
     echo Built ${IMAGE}
-done
+}
+
+if [ "$1" != "" ]; then
+    build_image "$1/Dockerfile"
+else
+    for i in */Dockerfile; do
+        build_image ${i}
+    done
+fi

--- a/scripts/version
+++ b/scripts/version
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"
@@ -8,13 +9,9 @@ COMMIT=$(git rev-parse --short HEAD)
 GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
 
 if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
-    VERSION=$GIT_TAG
-    IMAGE_VERSION=${VERSION}
+    VER=$GIT_TAG
 else
-    VERSION="${COMMIT}${DIRTY}"
-    IMAGE_VERSION=dev
+    VER="${COMMIT}${DIRTY}"
 fi
 
-if [ -z "$ARCH" ]; then
-    ARCH=amd64
-fi
+echo ${VER}


### PR DESCRIPTION
also, put the latest git commit as version (vs :dev) for untagged commits