### PR TITLE
Vault Volume Driver Support

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,10 @@ func main() {
 			Usage:  "The DOCKER_HOST to connect to",
 			EnvVar: "DOCKER_HOST",
 		},
+		cli.BoolFlag{
+			Name:  "save-on-attach",
+			Usage: "Save volume to Rancher on Volume attach call",
+		},
 	}
 	logrus.Info("Running")
 	app.Run(os.Args)
@@ -106,6 +110,8 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	d.SaveOnAttach = c.Bool("save-on-attach")
 
 	logrus.Infof("Starting plugin for %s", driverName)
 	h := volume.NewHandler(d)

--- a/package/secrets-bridge-v2/Dockerfile
+++ b/package/secrets-bridge-v2/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y jq curl nfs-common
+COPY storage /usr/bin/
+COPY common/* /usr/bin/
+ADD https://github.com/rancher/secrets-bridge-v2/releases/download/v0.1.0/secrets-bridge-v2 /usr/bin/secrets-bridge-v2
+RUN chmod +x /usr/bin/secrets-bridge-v2
+CMD /bin/bash -c '/usr/bin/start.sh storage --save-on-attach --driver-name secrets-bridge-v2 --cattle-access-key ${CATTLE_ACCESS_KEY} --cattle-secret-key ${CATTLE_SECRET_KEY}'


### PR DESCRIPTION
Add `--save-on-attach` CLI option so that save method can be called when updating `Device` string from volume driver return type.