### PR TITLE
Support spaces in the exportDir for rancher-nfs

### DIFF
--- a/package/nfs/rancher-nfs
+++ b/package/nfs/rancher-nfs
@@ -20,7 +20,7 @@ mount_nfs() {
         if [ ! -z "$opts" ]; then
             cmd="$cmd -o $opts"
         fi
-        cmd="$cmd $host:$exportDir $mountDir"
+        cmd="$cmd $host:\"$exportDir\" $mountDir"
 
         error=`$cmd 2>&1`
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
Previously, having an export(Dir) with a space in the path would cause errors, this should fix that.