### PR TITLE
feat: add EBS partition support

### DIFF
--- a/package/abs/Dockerfile
+++ b/package/abs/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 RUN apt-get update && \
     apt-get install -y jq python2.7 python-pip curl
-RUN pip install --upgrade pip && \
+RUN python -m pip install --force-reinstall pip && \
     pip install aliyun-python-sdk-ecs && \
     pip install aliyuncli
 COPY storage /usr/bin/

--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -90,6 +90,12 @@ find_matching_linux_device_path() {
 
         local device_new_format="/dev/xvd""${1: -1}"
         local linux_device_path=`lsblk -o KNAME | sed -e 's/^/\/dev\//' | grep "${device_new_format}"`
+        if [ "$(wc -w <<< ${linux_device_path})" -gt 1 ]; then
+            local linux_device_array=(${linux_device_path})
+            echo ${linux_device_array[1]}
+            break
+        fi
+
         if [ "${linux_device_path}" == "${device_new_format}" ]; then
             echo ${linux_device_path}
             break


### PR DESCRIPTION
This PR addresses the scenario where an existing EBS snapshot or volume has been created with a partition rather than creating a filesystem on the "raw" EBS volume mount.  

Currently, if a partition exists grep will return a list of device paths. This then fails to mount the volume on the host. The assumption here is that the disk has only one partition. I opted to create an index and reference the partition, so that later an option flag could be provided to specify which partition to mount.  

This addresses: https://github.com/rancher/rancher/issues/12106