### PR TITLE
Pull latest EBS snapshot from tag instead of failing.

### DIFF
--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -114,13 +114,13 @@ find_matching_linux_device_path() {
 }
 
 find_matching_snapshot() {
-    local snapshots
-    snapshots=`aws ec2 describe-snapshots --region=${EC2_REGION} --filters "Name=tag:${1},Values=${2}" | jq -r '.Snapshots | sort_by(.startTime) | last | .SnapshotId'`
+    local snapshot
+    snapshot=`aws ec2 describe-snapshots --region=${EC2_REGION} --filters "Name=tag:${1},Values=${2}" | jq -r '.Snapshots | sort_by(.startTime) | last | .SnapshotId'`
     if [ $? -ne 0 ]; then
-        print_error "Failed to describe snapshot for tags ${1}. ${snapshots}"
+        print_error "Failed to describe snapshot for tags ${1}. ${snapshot}"
     fi
 
-    echo $snapshots
+    echo $snapshot
 }
 
 init()

--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -115,14 +115,11 @@ find_matching_linux_device_path() {
 
 find_matching_snapshot() {
     local snapshots
-    snapshots=`aws ec2 describe-tags --region ${EC2_REGION} --filters "Name=resource-type,Values=snapshot" "Name=key,Values=${1}" "Name=value,Values=${2}" | jq -r '.Tags[].ResourceId'`
+    snapshots=`aws ec2 describe-snapshots --region=${EC2_REGION} --filters "Name=tag:${1},Values=${2}" | jq -r '.Snapshots | sort_by(.startTime) | last | .SnapshotId'`
     if [ $? -ne 0 ]; then
         print_error "Failed to describe snapshot for tags ${1}. ${snapshots}"
     fi
-    if [ $(echo "$snapshots" | wc -l) -ne 1 ]; then
-        # non-unique tag
-        print_error "Failed too many snapshots are tagged with ${1}. ${snapshots}"
-    fi
+
     echo $snapshots
 }
 

--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -115,7 +115,7 @@ find_matching_linux_device_path() {
 
 find_matching_snapshot() {
     local snapshot
-    snapshot=`aws ec2 describe-snapshots --region=${EC2_REGION} --filters "Name=tag:${1},Values=${2}" | jq -r '.Snapshots | sort_by(.startTime) | last | .SnapshotId'`
+    snapshot=`aws ec2 describe-snapshots --region ${EC2_REGION} --filters "Name=tag:${1},Values=${2}" | jq -r '.Snapshots | sort_by(.startTime) | last | .SnapshotId'`
     if [ $? -ne 0 ]; then
         print_error "Failed to describe snapshot for tags ${1}. ${snapshot}"
     fi


### PR DESCRIPTION
In many use cases it makes sense to have multiple snapshots under a tag. Rather than failing, Rancher EBS should pull the latest snapshot from the tag.

Tested this on Rancher v1.6.24