### PR TITLE
Device path limit bug fix

### DIFF
--- a/package/ebs/rancher-ebs
+++ b/package/ebs/rancher-ebs
@@ -191,6 +191,13 @@ create() {
 
     get_meta_data
 
+    # check if we have an available device path to mount
+    local device_path=$(find_available_device_path)
+    if [ "$device_path" == "" ]; then
+        print_error All device paths are in use for instance-id: ${INSTANCE_ID}
+    fi
+    
+
     if [ ! -z "${snapshot_tag}" ]; then
         snapshot=$(find_matching_snapshot "$tag_name" "$snapshot_tag")
     fi


### PR DESCRIPTION
http://support.rancher.com/hc/requests/4886 proposed fix

Reports an error in EBS storage service logs if there is no available device path to attach an EBS volume to for the target host. This prevents a loop which would spawn detached volumes filling up an AWS account if an EC2 instance already had all device paths filled with attached volumes.